### PR TITLE
Fix merge conflicts with zingolabs/dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,31 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets
 
+  doc:
+    name: Cargo Doc
+    runs-on: arc-sh-runners
+    needs: compute-tag
+    container:
+      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: MinIO Cache (cargo + target)
+        uses: tespkg/actions-cache@v1
+        with:
+          endpoint: ${{ env.CACHE_ENDPOINT }}
+          port: ${{ env.CACHE_PORT }}
+          bucket: ${{ env.CACHE_BUCKET }}
+          insecure: ${{ env.INSECURE_CACHE }}
+          key: cargo-deps-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-deps-
+          path: |
+            ~/.cargo
+            target
+
+      - name: Check documentation
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
   whitespace:
     name: Whitespace check
     runs-on: arc-sh-runners

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Certain situations may arise where experienced Zaino developers might bypass the
 Finally, see our [Software Philosophy](#software-philosophy), and understand you are contribuing to a project with these principles at work.
 
 ## Block Explorer Merge Requirements
-This is an evloving document: the following merge requirements are intended to be constrained to the specific case of implementations of Block Explorer RPCs.
+This is an evolving document: the following merge requirements are intended for the specific case of Block Explorer RPCs.
 
 Any use of `TODO`s makes a PR invalid for merging into `dev`.
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -69,6 +69,10 @@ ENV CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
 ENV PATH="/usr/local/bin:${PATH}"
 ENV CARGO_TERM_COLOR=always
 
+# Use system rocksdb instead of building from source
+ENV ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu
+ENV ROCKSDB_INCLUDE_DIR=/usr/include
+
 LABEL maintainer="nachog00"
 LABEL org.zaino.test-artifacts.versions.rust="${RUST_VERSION}"
 
@@ -77,6 +81,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     libclang-dev \
     build-essential \
+    librocksdb-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install rustup (Rust toolchain manager) and set up the Rust toolchain

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,7 +99,9 @@ docker build -f Dockerfile.ci \
   --build-arg ZCASH_VERSION=$ZCASH_VERSION \
   --build-arg ZEBRA_VERSION=$ZEBRA_VERSION \
   --build-arg RUST_VERSION=$RUST_VERSION \
-  -t ${IMAGE_NAME}:$TAG .
+  -t ${IMAGE_NAME}:$TAG \
+  ${@} \
+  .
 '''
 
 # -------------------------------------------------------------------

--- a/zaino-fetch/src/chain/block.rs
+++ b/zaino-fetch/src/chain/block.rs
@@ -26,7 +26,7 @@ struct BlockHeaderData {
     /// a free field. The only constraint is that it must be at least `4` when
     /// interpreted as an `i32`.
     ///
-    /// Size [bytes]: 4
+    /// Size \[bytes\]: 4
     version: i32,
 
     /// The hash of the previous block, used to create a chain of blocks back to
@@ -35,7 +35,7 @@ struct BlockHeaderData {
     /// This ensures no previous block can be changed without also changing this
     /// block's header.
     ///
-    /// Size [bytes]: 32
+    /// Size \[bytes\]: 32
     hash_prev_block: Vec<u8>,
 
     /// The root of the Bitcoin-inherited transaction Merkle tree, binding the
@@ -47,21 +47,21 @@ struct BlockHeaderData {
     /// transactions with the same Merkle root, although only one set will be
     /// valid.
     ///
-    /// Size [bytes]: 32
+    /// Size \[bytes\]: 32
     hash_merkle_root: Vec<u8>,
 
-    /// [Pre-Sapling] A reserved field which should be ignored.
-    /// [Sapling onward] The root LEBS2OSP_256(rt) of the Sapling note
+    /// \[Pre-Sapling\] A reserved field which should be ignored.
+    /// \[Sapling onward\] The root LEBS2OSP_256(rt) of the Sapling note
     /// commitment tree corresponding to the final Sapling treestate of this
     /// block.
     ///
-    /// Size [bytes]: 32
+    /// Size \[bytes\]: 32
     hash_final_sapling_root: Vec<u8>,
 
     /// The block timestamp is a Unix epoch time (UTC) when the miner
     /// started hashing the header (according to the miner).
     ///
-    /// Size [bytes]: 4
+    /// Size \[bytes\]: 4
     time: u32,
 
     /// An encoded version of the target threshold this block's header
@@ -73,19 +73,19 @@ struct BlockHeaderData {
     ///
     /// [Bitcoin-nBits](https://bitcoin.org/en/developer-reference#target-nbits)
     ///
-    /// Size [bytes]: 4
+    /// Size \[bytes\]: 4
     n_bits_bytes: Vec<u8>,
 
     /// An arbitrary field that miners can change to modify the header
     /// hash in order to produce a hash less than or equal to the
     /// target threshold.
     ///
-    /// Size [bytes]: 32
+    /// Size \[bytes\]: 32
     nonce: Vec<u8>,
 
     /// The Equihash solution.
     ///
-    /// Size [bytes]: CompactLength
+    /// Size \[bytes\]: CompactLength
     solution: Vec<u8>,
 }
 
@@ -252,7 +252,7 @@ impl FullBlockHeader {
 pub struct FullBlock {
     /// The block header, containing block metadata.
     ///
-    /// Size [bytes]: 140+CompactLength
+    /// Size \[bytes\]: 140+CompactLength
     hdr: FullBlockHeader,
 
     /// The block transactions.
@@ -326,7 +326,7 @@ impl ParseFromSlice for FullBlock {
 /// Genesis block special case.
 ///
 /// From LightWalletD:
-/// see https://github.com/zcash/lightwalletd/issues/17#issuecomment-467110828.
+/// see <https://github.com/zcash/lightwalletd/issues/17#issuecomment-467110828>.
 const GENESIS_TARGET_DIFFICULTY: u32 = 520617983;
 
 impl FullBlock {

--- a/zaino-fetch/src/chain/transaction.rs
+++ b/zaino-fetch/src/chain/transaction.rs
@@ -9,18 +9,18 @@ use zaino_proto::proto::compact_formats::{
     CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
 };
 
-/// Txin format as described in https://en.bitcoin.it/wiki/Transaction
+/// Txin format as described in <https://en.bitcoin.it/wiki/Transaction>
 #[derive(Debug, Clone)]
 struct TxIn {
-    // PrevTxHash - Size[bytes]: 32
+    // PrevTxHash - Size\[bytes\]: 32
     prev_txid: Vec<u8>,
-    // PrevTxOutIndex - Size[bytes]: 4
+    // PrevTxOutIndex - Size\[bytes\]: 4
     prev_index: u32,
     /// CompactSize-prefixed, could be a pubkey or a script
     ///
-    /// Size[bytes]: CompactSize
+    /// Size\[bytes\]: CompactSize
     script_sig: Vec<u8>,
-    // SequenceNumber [IGNORED] - Size[bytes]: 4
+    // SequenceNumber \[IGNORED\] - Size\[bytes\]: 4
 }
 
 impl TxIn {
@@ -70,14 +70,14 @@ impl ParseFromSlice for TxIn {
     }
 }
 
-/// Txout format as described in https://en.bitcoin.it/wiki/Transaction
+/// Txout format as described in <https://en.bitcoin.it/wiki/Transaction>
 #[derive(Debug, Clone)]
 struct TxOut {
     /// Non-negative int giving the number of zatoshis to be transferred
     ///
-    /// Size[bytes]: 8
+    /// Size\[bytes\]: 8
     value: u64,
-    // Script - Size[bytes]: CompactSize
+    // Script - Size\[bytes\]: CompactSize
     script_hash: Vec<u8>,
 }
 
@@ -150,15 +150,15 @@ fn parse_transparent(data: &[u8]) -> Result<(&[u8], Vec<TxIn>, Vec<TxOut>), Pars
 /// protocol specification.
 #[derive(Debug, Clone)]
 struct Spend {
-    // Cv [IGNORED] - Size[bytes]: 32
-    // Anchor [IGNORED] - Size[bytes]: 32
+    // Cv \[IGNORED\] - Size\[bytes\]: 32
+    // Anchor \[IGNORED\] - Size\[bytes\]: 32
     /// A nullifier to a sapling note.
     ///
-    /// Size[bytes]: 32
+    /// Size\[bytes\]: 32
     nullifier: Vec<u8>,
-    // Rk [IGNORED] - Size[bytes]: 32
-    // Zkproof [IGNORED] - Size[bytes]: 192
-    // SpendAuthSig [IGNORED] - Size[bytes]: 64
+    // Rk \[IGNORED\] - Size\[bytes\]: 32
+    // Zkproof \[IGNORED\] - Size\[bytes\]: 192
+    // SpendAuthSig \[IGNORED\] - Size\[bytes\]: 64
 }
 
 impl Spend {
@@ -204,22 +204,22 @@ impl ParseFromSlice for Spend {
 /// Zcash protocol spec.
 #[derive(Debug, Clone)]
 struct Output {
-    // Cv [IGNORED] - Size[bytes]: 32
+    // Cv \[IGNORED\] - Size\[bytes\]: 32
     /// U-coordinate of the note commitment, derived from the note's value, recipient, and a
     /// random value.
     ///
-    /// Size[bytes]: 32
+    /// Size\[bytes\]: 32
     cmu: Vec<u8>,
     /// Ephemeral public key for Diffie-Hellman key exchange.
     ///
-    /// Size[bytes]: 32
+    /// Size\[bytes\]: 32
     ephemeral_key: Vec<u8>,
     /// Encrypted transaction details including value transferred and an optional memo.
     ///
-    /// Size[bytes]: 580
+    /// Size\[bytes\]: 580
     enc_ciphertext: Vec<u8>,
-    // OutCiphertext [IGNORED] - Size[bytes]: 80
-    // Zkproof [IGNORED] - Size[bytes]: 192
+    // OutCiphertext \[IGNORED\] - Size\[bytes\]: 80
+    // Zkproof \[IGNORED\] - Size\[bytes\]: 192
 }
 
 impl Output {
@@ -273,16 +273,16 @@ impl ParseFromSlice for Output {
 /// NOTE: Legacy, no longer used but included for consistency.
 #[derive(Debug, Clone)]
 struct JoinSplit {
-    //vpubOld [IGNORED] - Size[bytes]: 8
-    //vpubNew [IGNORED] - Size[bytes]: 8
-    //anchor [IGNORED] - Size[bytes]: 32
-    //nullifiers [IGNORED] - Size[bytes]: 64/32
-    //commitments [IGNORED] - Size[bytes]: 64/32
-    //ephemeralKey [IGNORED] - Size[bytes]: 32
-    //randomSeed [IGNORED] - Size[bytes]: 32
-    //vmacs [IGNORED] - Size[bytes]: 64/32
-    //proofGroth16 [IGNORED] - Size[bytes]: 192
-    //encCiphertexts [IGNORED] - Size[bytes]: 1202
+    //vpubOld \[IGNORED\] - Size\[bytes\]: 8
+    //vpubNew \[IGNORED\] - Size\[bytes\]: 8
+    //anchor \[IGNORED\] - Size\[bytes\]: 32
+    //nullifiers \[IGNORED\] - Size\[bytes\]: 64/32
+    //commitments \[IGNORED\] - Size\[bytes\]: 64/32
+    //ephemeralKey \[IGNORED\] - Size\[bytes\]: 32
+    //randomSeed \[IGNORED\] - Size\[bytes\]: 32
+    //vmacs \[IGNORED\] - Size\[bytes\]: 64/32
+    //proofGroth16 \[IGNORED\] - Size\[bytes\]: 192
+    //encCiphertexts \[IGNORED\] - Size\[bytes\]: 1202
 }
 
 impl ParseFromSlice for JoinSplit {
@@ -325,25 +325,25 @@ impl ParseFromSlice for JoinSplit {
 /// An Orchard action.
 #[derive(Debug, Clone)]
 struct Action {
-    // Cv [IGNORED] - Size[bytes]: 32
+    // Cv \[IGNORED\] - Size\[bytes\]: 32
     /// A nullifier to a orchard note.
     ///
-    /// Size[bytes]: 32
+    /// Size\[bytes\]: 32
     nullifier: Vec<u8>,
-    // Rk [IGNORED] - Size[bytes]: 32
+    // Rk \[IGNORED\] - Size\[bytes\]: 32
     /// X-coordinate of the commitment to the note.
     ///
-    /// Size[bytes]: 32
+    /// Size\[bytes\]: 32
     cmx: Vec<u8>,
     /// Ephemeral public key.
     ///
-    /// Size[bytes]: 32
+    /// Size\[bytes\]: 32
     ephemeral_key: Vec<u8>,
     /// Encrypted details of the new note, including its value and recipient's data.
     ///
-    /// Size[bytes]: 580
+    /// Size\[bytes\]: 580
     enc_ciphertext: Vec<u8>,
-    // OutCiphertext [IGNORED] - Size[bytes]: 80
+    // OutCiphertext \[IGNORED\] - Size\[bytes\]: 80
 }
 
 impl Action {
@@ -400,57 +400,57 @@ impl ParseFromSlice for Action {
 struct TransactionData {
     /// Indicates if the transaction is an Overwinter-enabled transaction.
     ///
-    /// Size[bytes]: [in 4 byte header]
+    /// Size\[bytes\]: [in 4 byte header]
     f_overwintered: bool,
     /// The transaction format version.
     ///
-    /// Size[bytes]: [in 4 byte header]
+    /// Size\[bytes\]: [in 4 byte header]
     version: u32,
     /// Version group ID, used to specify transaction type and validate its components.
     ///
-    /// Size[bytes]: 4
+    /// Size\[bytes\]: 4
     n_version_group_id: u32,
     /// Consensus branch ID, used to identify the network upgrade that the transaction is valid for.
     ///
-    /// Size[bytes]: 4
+    /// Size\[bytes\]: 4
     consensus_branch_id: u32,
     /// List of transparent inputs in a transaction.
     ///
-    /// Size[bytes]: Vec<40+CompactSize>
+    /// Size\[bytes\]: Vec<40+CompactSize>
     transparent_inputs: Vec<TxIn>,
     /// List of transparent outputs in a transaction.
     ///
-    /// Size[bytes]: Vec<8+CompactSize>
+    /// Size\[bytes\]: Vec<8+CompactSize>
     transparent_outputs: Vec<TxOut>,
-    // NLockTime [IGNORED] - Size[bytes]: 4
-    // NExpiryHeight [IGNORED] - Size[bytes]: 4
-    // ValueBalanceSapling - Size[bytes]: 8
+    // NLockTime \[IGNORED\] - Size\[bytes\]: 4
+    // NExpiryHeight \[IGNORED\] - Size\[bytes\]: 4
+    // ValueBalanceSapling - Size\[bytes\]: 8
     /// Value balance for the Sapling pool (v4/v5). None if not present.
     value_balance_sapling: Option<i64>,
     /// List of shielded spends from the Sapling pool
     ///
-    /// Size[bytes]: Vec<384>
+    /// Size\[bytes\]: Vec<384>
     shielded_spends: Vec<Spend>,
     /// List of shielded outputs from the Sapling pool
     ///
-    /// Size[bytes]: Vec<948>
+    /// Size\[bytes\]: Vec<948>
     shielded_outputs: Vec<Output>,
     /// List of JoinSplit descriptions in a transaction, no longer supported.
     ///
-    /// Size[bytes]: Vec<1602-1698>
+    /// Size\[bytes\]: Vec<1602-1698>
     #[allow(dead_code)]
     join_splits: Vec<JoinSplit>,
-    /// joinSplitPubKey [IGNORED] - Size[bytes]: 32
-    /// joinSplitSig [IGNORED] - Size[bytes]: 64
-    /// bindingSigSapling [IGNORED] - Size[bytes]: 64
+    /// joinSplitPubKey \[IGNORED\] - Size\[bytes\]: 32
+    /// joinSplitSig \[IGNORED\] - Size\[bytes\]: 64
+    /// bindingSigSapling \[IGNORED\] - Size\[bytes\]: 64
     /// List of Orchard actions.
     ///
-    /// Size[bytes]: Vec<820>
+    /// Size\[bytes\]: Vec<820>
     orchard_actions: Vec<Action>,
-    /// ValueBalanceOrchard - Size[bytes]: 8
+    /// ValueBalanceOrchard - Size\[bytes\]: 8
     /// Value balance for the Orchard pool (v5 only). None if not present.
     value_balance_orchard: Option<i64>,
-    /// AnchorOrchard - Size[bytes]: 32
+    /// AnchorOrchard - Size\[bytes\]: 32
     /// In non-coinbase transactions, this is the anchor (authDataRoot) of a prior block's Orchard note commitment tree.
     /// In the coinbase transaction, this commits to the final Orchard tree state for the current block — i.e., it *is* the block's authDataRoot.
     /// Present in v5 transactions only, if any Orchard actions exist in the block.
@@ -829,7 +829,7 @@ impl FullTransaction {
 
     /// Returns sapling and orchard value balances for the transaction.
     ///
-    /// Returned as (Option<valueBalanceSapling>, Option<valueBalanceOrchard>).
+    /// Returned as (Option\<valueBalanceSapling\>, Option\<valueBalanceOrchard\>).
     pub fn value_balances(&self) -> (Option<i64>, Option<i64>) {
         (
             self.raw_transaction.value_balance_sapling,

--- a/zaino-fetch/src/chain/utils.rs
+++ b/zaino-fetch/src/chain/utils.rs
@@ -34,7 +34,7 @@ pub(crate) fn skip_bytes(
     Ok(())
 }
 
-/// Reads the next n bytes from cursor into a vec<u8>, returns error message given if eof is reached.
+/// Reads the next n bytes from cursor into a `vec<u8>`, returns error message given if eof is reached.
 pub(crate) fn read_bytes(
     cursor: &mut Cursor<&[u8]>,
     n: usize,

--- a/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/zaino-fetch/src/jsonrpsee/connector.rs
@@ -1,7 +1,7 @@
 //! JsonRPSee client implementation.
 //!
 //! TODO: - Add option for http connector.
-//!       - Refactor JsonRPSeecConnectorError into concrete error types and implement fmt::display [https://github.com/zingolabs/zaino/issues/67].
+//!       - Refactor JsonRPSeecConnectorError into concrete error types and implement fmt::display [<https://github.com/zingolabs/zaino/issues/67>].
 
 use base64::{engine::general_purpose, Engine};
 use http::Uri;
@@ -396,7 +396,7 @@ impl JsonRpSeeConnector {
         Ok(request_builder)
     }
 
-    /// Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+    /// Returns software information from the RPC server, as a [`crate::jsonrpsee::connector::GetInfoResponse`] JSON struct.
     ///
     /// zcashd reference: [`getinfo`](https://zcash.github.io/rpc/getinfo.html)
     /// method: post
@@ -406,7 +406,6 @@ impl JsonRpSeeConnector {
             .await
     }
 
-    /// Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
     ///
     /// zcashd reference: [`getblockchaininfo`](https://zcash.github.io/rpc/getblockchaininfo.html)
     /// method: post
@@ -430,7 +429,7 @@ impl JsonRpSeeConnector {
             .await
     }
 
-    /// Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+    /// Returns the total balance of a provided `addresses` in an [`crate::jsonrpsee::response::GetBalanceResponse`] instance.
     ///
     /// zcashd reference: [`getaddressbalance`](https://zcash.github.io/rpc/getaddressbalance.html)
     /// method: post
@@ -449,7 +448,6 @@ impl JsonRpSeeConnector {
     }
 
     /// Sends the raw bytes of a signed transaction to the local node's mempool, if the transaction is valid.
-    /// Returns the [`SentTransactionHash`] for the transaction, as a JSON string.
     ///
     /// zcashd reference: [`sendrawtransaction`](https://zcash.github.io/rpc/sendrawtransaction.html)
     /// method: post
@@ -467,7 +465,7 @@ impl JsonRpSeeConnector {
         self.send_request("sendrawtransaction", params).await
     }
 
-    /// Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+    /// Returns the requested block by hash or height, as a [`GetBlockResponse`].
     /// If the block is not in Zebra's state, returns
     /// [error code `-8`.](https://github.com/zcash/zcash/issues/5758)
     ///
@@ -511,7 +509,7 @@ impl JsonRpSeeConnector {
     /// The zcashd doc reference above says there are no parameters and the result is a "hex" (string) of the block hash hex encoded.
     /// The Zcash source code is considered canonical.
     /// [In the rpc definition](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/common.h#L48) there are no required params, or optional params.
-    /// [The function in rpc/blockchain.cpp]https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325
+    /// [The function in rpc/blockchain.cpp](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325)
     /// where `return chainActive.Tip()->GetBlockHash().GetHex();` is the [return expression](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L339)returning a `std::string`
     pub async fn get_best_blockhash(&self) -> Result<GetBlockHash, RpcRequestError<Infallible>> {
         self.send_request::<(), GetBlockHash>("getbestblockhash", ())
@@ -589,7 +587,7 @@ impl JsonRpSeeConnector {
         self.send_request("z_getsubtreesbyindex", params).await
     }
 
-    /// Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+    /// Returns the raw transaction data, as a [`GetTransactionResponse`].
     ///
     /// zcashd reference: [`getrawtransaction`](https://zcash.github.io/rpc/getrawtransaction.html)
     /// method: post

--- a/zaino-fetch/src/jsonrpsee/error.rs
+++ b/zaino-fetch/src/jsonrpsee/error.rs
@@ -61,7 +61,7 @@ pub enum TransportError {
 impl TransportError {
     /// Converts TransportError to tonic::Status
     ///
-    /// TODO: This impl should be changed to return the correct status [https://github.com/zcash/lightwalletd/issues/497] before release,
+    /// TODO: This impl should be changed to return the correct status [per this issue](https://github.com/zcash/lightwalletd/issues/497) before release,
     ///       however propagating the server error is useful during development.
     pub fn to_grpc_status(&self) -> tonic::Status {
         // TODO: Hide server error from clients before release. Currently useful for dev purposes.

--- a/zaino-fetch/src/jsonrpsee/response.rs
+++ b/zaino-fetch/src/jsonrpsee/response.rs
@@ -26,7 +26,7 @@ impl TryFrom<RpcError> for Infallible {
 
 /// Response to a `getinfo` RPC request.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_info`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_info`].
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetInfoResponse {
     /// The node version
@@ -140,7 +140,7 @@ impl From<GetInfoResponse> for zebra_rpc::methods::GetInfo {
 
 /// Response to a `getblockchaininfo` RPC request.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_blockchain_info`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_blockchain_info`].
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetBlockchainInfoResponse {
     /// Current network name as defined in BIP70 (main, test, regtest)
@@ -337,7 +337,7 @@ impl TryFrom<GetBlockchainInfoResponse> for zebra_rpc::methods::GetBlockChainInf
 
 /// The transparent balance of a set of addresses.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_address_balance`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_address_balance`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetBalanceResponse {
     /// The total transparent balance.
@@ -378,7 +378,7 @@ impl From<GetBalanceResponse> for zebra_rpc::methods::AddressBalance {
 
 /// Contains the hex-encoded hash of the sent transaction.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::send_raw_transaction`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::send_raw_transaction`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SendTransactionResponse(#[serde(with = "hex")] pub zebra_chain::transaction::Hash);
 
@@ -430,7 +430,6 @@ impl From<SendTransactionResponse> for zebra_rpc::methods::SentTransactionHash {
 ///
 /// Contains the hex-encoded hash of the requested block.
 ///
-/// Also see the notes for the [`Rpc::get_best_block_hash`] and `get_block_hash` methods.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct GetBlockHash(#[serde(with = "hex")] pub zebra_chain::block::Hash);
@@ -453,7 +452,7 @@ impl From<GetBlockHash> for zebra_rpc::methods::GetBlockHash {
 
 /// A wrapper struct for a zebra serialized block.
 ///
-/// Stores bytes that are guaranteed to be deserializable into a [`Block`].
+/// Stores bytes that are guaranteed to be deserializable into a [`zebra_chain::block::Block`].
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SerializedBlock(zebra_chain::block::SerializedBlock);
 
@@ -609,7 +608,7 @@ impl From<Solution> for zebra_chain::work::equihash::Solution {
 
 /// Contains the hex-encoded hash of the sent transaction.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_block`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_block`].
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 pub enum GetBlockResponse {
@@ -692,7 +691,7 @@ impl From<GetBlockCountResponse> for Height {
 
 /// A block object containing data and metadata about a block.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_block`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_block`].
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BlockObject {
     /// The hash of the requested block.
@@ -828,7 +827,7 @@ impl TryFrom<GetBlockResponse> for zebra_rpc::methods::GetBlock {
 
 /// Vec of transaction ids, as a JSON array.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_raw_mempool`] and [`JsonRpcConnector::get_address_txids`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_raw_mempool`] and [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_address_txids`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct TxidsResponse {
     /// Vec of txids.
@@ -902,11 +901,11 @@ impl<'de> serde::Deserialize<'de> for TxidsResponse {
 }
 
 /// Contains the hex-encoded Sapling & Orchard note commitment trees, and their
-/// corresponding [`block::Hash`], [`Height`], and block time.
+/// corresponding `block::Hash`, `Height`, and block time.
 ///
 /// Encoded using v0 frontier encoding.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_treestate`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_treestate`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct GetTreestateResponse {
     /// The block height corresponding to the treestate, numeric.
@@ -1020,7 +1019,7 @@ impl TryFrom<GetTreestateResponse> for zebra_rpc::methods::trees::GetTreestate {
 
 /// Contains raw transaction, encoded as hex bytes.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_raw_transaction`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_raw_transaction`].
 #[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub enum GetTransactionResponse {
     /// The raw transaction, encoded as hex bytes.
@@ -1251,7 +1250,7 @@ impl<'de> serde::Deserialize<'de> for SubtreeRpcData {
 /// Contains the Sapling or Orchard pool label, the index of the first subtree in the list,
 /// and a list of subtree roots and end heights.
 ///
-/// This is used for the output parameter of [`JsonRpcConnector::get_subtrees_by_index`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_subtrees_by_index`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetSubtreesResponse {
     /// The shielded pool to which the subtrees belong.
@@ -1313,7 +1312,7 @@ impl From<GetSubtreesResponse> for zebra_rpc::methods::trees::GetSubtrees {
 ///
 /// # Correctness
 ///
-/// Consensus-critical serialization uses [`ZcashSerialize`].
+/// Consensus-critical serialization uses `ZcashSerialize`.
 /// [`serde`]-based hex serialization must only be used for RPCs and testing.
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]
 pub struct Script(zebra_chain::transparent::Script);
@@ -1370,7 +1369,7 @@ impl<'de> serde::Deserialize<'de> for Script {
     }
 }
 
-/// This is used for the output parameter of [`JsonRpcConnector::get_address_utxos`].
+/// This is used for the output parameter of [`crate::jsonrpsee::connector::JsonRpSeeConnector::get_address_utxos`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetUtxosResponse {
     /// The transparent address, base58check encoded

--- a/zaino-serve/src/rpc/grpc/service.rs
+++ b/zaino-serve/src/rpc/grpc/service.rs
@@ -81,15 +81,15 @@ macro_rules! client_method_helper {
 /// streaming/nonstreaming.
 ///
 /// Arguments:
-/// comment method_name(input_type) -> return [as streaming],
-/// [comment] A str literal to be used a doc-comment for the method.
-/// [method_name] The name of the method to implement
-/// [input_type] The type of the tonic Request to accept as an argument
-/// [as streaming/empty] the optional literal characters
+/// comment method_name(input_type) -> return \[as streaming\],
+/// \[comment\] A str literal to be used a doc-comment for the method.
+/// \[method_name\] The name of the method to implement
+/// \[input_type\] The type of the tonic Request to accept as an argument
+/// \[as streaming/empty\] the optional literal characters
 ///     'as streaming', 'as empty', or 'as streamingempty'
 ///     needed when the return type is a Streaming type, and/or
 ///     the argument type isn't used
-/// [return] the return type of the function
+/// \[return\] the return type of the function
 macro_rules! implement_client_methods {
     ($($comment:literal $method_name:ident($input_type:ty ) -> $return:ty $( as $streaming:ident)? ,)+) => {
         $(
@@ -185,7 +185,9 @@ where
         get_mempool_stream(Empty) -> Self::GetMempoolStreamStream as streamingempty,
         "Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production) [from zebrad] \
         This RPC has not been implemented as it is not currently used by zingolib. \
-        If you require this RPC please open an issue or PR at the Zingo-Indexer github (https://github.com/zingolabs/zingo-indexer)."
+        If you require this RPC please open an issue or PR at [https://github.com/zingolabs/zaino]\
+        (https://github.com/zingolabs/zaino)."
+
         ping(Duration) -> PingResponse,
     );
 

--- a/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -60,7 +60,7 @@ pub trait ZcashIndexerRpc {
     /// The zcashd doc reference above says there are no parameters and the result is a "hex" (string) of the block hash hex encoded.
     /// The Zcash source code is considered canonical:
     /// [In the rpc definition](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/common.h#L48) there are no required params, or optional params.
-    /// [The function in rpc/blockchain.cpp]https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325
+    /// [The function in rpc/blockchain.cpp](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325)
     /// where `return chainActive.Tip()->GetBlockHash().GetHex();` is the [return expression](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L339)returning a `std::string`
     #[method(name = "getbestblockhash")]
     async fn get_best_blockhash(&self) -> Result<GetBlockHash, ErrorObjectOwned>;

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -54,7 +54,7 @@ use crate::{
 ///
 /// NOTE: We currently do not implement clone for chain fetch services as this service is responsible for maintaining and closing its child processes.
 ///       ServiceSubscribers are used to create separate chain fetch processes while allowing central state processes to be managed in a single place.
-///       If we want the ability to clone Service all JoinHandle's should be converted to Arc<JoinHandle>.
+///       If we want the ability to clone Service all JoinHandle's should be converted to Arc\<JoinHandle\>.
 #[derive(Debug)]
 pub struct FetchService {
     /// JsonRPC Client.
@@ -350,7 +350,7 @@ impl ZcashIndexer for FetchServiceSubscriber {
     ///
     /// The Zcash source code is considered canonical:
     /// [In the rpc definition](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/common.h#L48) there are no required params, or optional params.
-    /// [The function in rpc/blockchain.cpp]https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325
+    /// [The function in rpc/blockchain.cpp](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325)
     /// where `return chainActive.Tip()->GetBlockHash().GetHex();` is the [return expression](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L339)returning a `std::string`
     async fn get_best_blockhash(&self) -> Result<GetBlockHash, Self::Error> {
         Ok(self.fetcher.get_best_blockhash().await?.into())

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -91,7 +91,7 @@ macro_rules! expected_read_response {
 ///       ServiceSubscribers are used to create separate chain fetch processes
 /// while allowing central state processes to be managed in a single place.
 ///       If we want the ability to clone Service all JoinHandle's should be
-/// converted to Arc<JoinHandle>.
+/// converted to Arc\<JoinHandle\>.
 #[derive(Debug)]
 pub struct StateService {
     /// `ReadeStateService` from Zebra-State.
@@ -251,7 +251,6 @@ impl ZcashService for StateService {
         Ok(state_service)
     }
 
-    /// returns a [`fetchservicesubscriber`].
     fn get_subscriber(&self) -> IndexerSubscriber<StateServiceSubscriber> {
         IndexerSubscriber::new(StateServiceSubscriber {
             read_state_service: self.read_state_service.clone(),
@@ -1093,7 +1092,7 @@ impl ZcashIndexer for StateServiceSubscriber {
     /// Return the hex encoded hash of the best (tip) block, in the longest block chain.
     /// The Zcash source code is considered canonical:
     /// [In the rpc definition](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/common.h#L48) there are no required params, or optional params.
-    /// [The function in rpc/blockchain.cpp]https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325
+    /// [The function in rpc/blockchain.cpp](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325)
     /// where `return chainActive.Tip()->GetBlockHash().GetHex();` is the [return expression](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L339)returning a `std::string`
     async fn get_best_blockhash(&self) -> Result<GetBlockHash, Self::Error> {
         // return should be valid hex encoded.

--- a/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/zaino-state/src/chain_index/non_finalised_state.rs
@@ -642,7 +642,7 @@ impl NonFinalizedState {
         }
     }
 
-    /// Get a copy of the block cache as it existed at the last [update] call
+    /// Get a copy of the block cache as it existed at the last [`Self::update`] call
     pub fn get_snapshot(&self) -> Arc<NonfinalizedBlockCacheSnapshot> {
         self.current.load_full()
     }

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -31,7 +31,7 @@ impl Hash {
         reversed_bytes
     }
 
-    /// Convert bytes in big-endian byte-order into a [`block::Hash`](crate::block::Hash).
+    /// Convert bytes in big-endian byte-order into a [`block::Hash`](crate::Hash).
     pub fn from_bytes_in_display_order(bytes_in_display_order: &[u8; 32]) -> Hash {
         let mut internal_byte_order = *bytes_in_display_order;
         internal_byte_order.reverse();
@@ -559,8 +559,8 @@ pub struct BlockData {
     /// Merkle root hash of all transaction IDs in the block (used for quick tx inclusion proofs).
     pub(super) merkle_root: [u8; 32],
     /// Digest representing the block-commitments Merkle root (commitment to note states).
-    /// - < V4: [`hashFinalSaplingRoot`] - Sapling note commitment tree root.
-    /// - => V4: [`hashBlockCommitments`] - digest over hashLightClientRoot and hashAuthDataRoot.``
+    /// - < V4: `hashFinalSaplingRoot` - Sapling note commitment tree root.
+    /// - => V4: `hashBlockCommitments` - digest over hashLightClientRoot and hashAuthDataRoot.``
     pub(super) block_commitments: [u8; 32],
     /// Compact difficulty target used for proof-of-work and difficulty calculation.
     pub(super) bits: u32,
@@ -2138,11 +2138,11 @@ impl ZainoVersionedSerialise for AddrHistRecord {
 /// EXACTLY 17 bytes – duplicate value in `addr_hist` DBI.
 ///
 /// Layout (all big-endian except `value`):
-/// [0..4]  height
-/// [4..6]  tx_index
-/// [6..8]  vout
-/// [8]     flags
-/// [9..17] value  (little-endian, matches Zcashd)
+/// \[0..4\]  height
+/// \[4..6\]  tx_index
+/// \[6..8\]  vout
+/// \[8\]     flags
+/// \[9..17\] value  (little-endian, matches Zcashd)
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
 pub(crate) struct AddrEventBytes([u8; 17]);

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -21,10 +21,10 @@ pub enum BackendConfig {
     Fetch(FetchServiceConfig),
 }
 
-/// Holds config data for [`StateService`].
+/// Holds config data for [crate::StateService].
 #[derive(Debug, Clone)]
 pub struct StateServiceConfig {
-    /// Zebra [`ReadStateService`] config data
+    /// Zebra [`zebra_state::ReadStateService`] config data
     pub validator_config: zebra_state::Config,
     /// Validator JsonRPC address.
     pub validator_rpc_address: std::net::SocketAddr,
@@ -101,7 +101,7 @@ impl StateServiceConfig {
     }
 }
 
-/// Holds config data for [`FetchService`].
+/// Holds config data for [crate::FetchService].
 #[derive(Debug, Clone)]
 pub struct FetchServiceConfig {
     /// Validator JsonRPC address.
@@ -178,7 +178,7 @@ impl FetchServiceConfig {
     }
 }
 
-/// Holds config data for [`FetchService`].
+/// Holds config data for [`crate::FetchService`].
 #[derive(Debug, Clone)]
 pub struct BlockCacheConfig {
     /// Capacity of the Dashmap.

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -73,11 +73,11 @@ pub trait ZcashService: Sized {
     /// Service Config.
     type Config: Clone;
 
-    /// Spawns a [`Service`].
+    /// Spawns a [`ZcashIndexer`].
     async fn spawn(config: Self::Config)
         -> Result<Self, <Self::Subscriber as ZcashIndexer>::Error>;
 
-    /// Returns a [`ServiceSubscriber`].
+    /// Returns a [`IndexerSubscriber`].
     fn get_subscriber(&self) -> IndexerSubscriber<Self::Subscriber>;
 
     /// Fetches the current status
@@ -260,8 +260,8 @@ pub trait ZcashIndexer: Send + Sync + 'static {
     /// tags: blockchain
     /// The Zcash source code is considered canonical:
     /// [In the rpc definition](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/common.h#L48) there are no required params, or optional params.
-    /// [The function in rpc/blockchain.cpp]https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325
-    /// where `return chainActive.Tip()->GetBlockHash().GetHex();` is the [return expression](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L339)returning a `std::string`
+    /// [The function in rpc/blockchain.cpp](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L325)
+    /// where `return chainActive.Tip()->GetBlockHash().GetHex();` is the [return expression](https://github.com/zcash/zcash/blob/654a8be2274aa98144c80c1ac459400eaf0eacbe/src/rpc/blockchain.cpp#L339) returning a `std::string`
     async fn get_best_blockhash(&self) -> Result<GetBlockHash, Self::Error>;
 
     /// Returns all transaction ids in the memory pool, as a JSON array.

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -120,7 +120,7 @@ pub struct FinalisedState {
 }
 
 impl FinalisedState {
-    /// Spawns a new [`NonFinalisedState`] and syncs the FinalisedState to the servers finalised state.
+    /// Spawns a new [`Self`] and syncs the FinalisedState to the servers finalised state.
     ///
     /// Inputs:
     /// - fetcher: Json RPC client.
@@ -688,7 +688,7 @@ impl Drop for FinalisedState {
     }
 }
 
-/// A subscriber to a [`NonFinalisedState`].
+/// A subscriber to a [`crate::bench::chain_index::non_finalised_state::NonFinalizedState`].
 #[derive(Debug, Clone)]
 pub struct FinalisedStateSubscriber {
     request_sender: tokio::sync::mpsc::Sender<DbRequest>,

--- a/zaino-state/src/local_cache/mempool.rs
+++ b/zaino-state/src/local_cache/mempool.rs
@@ -237,7 +237,7 @@ impl MempoolSubscriber {
         self.subscriber.get_filtered_state(&HashSet::new())
     }
 
-    /// Returns all tx currently in the mempool filtered by [`exclude_list`].
+    /// Returns all tx currently in the mempool filtered by `exclude_list`.
     ///
     /// The transaction IDs in the Exclude list can be shortened to any number of bytes to make the request
     /// more bandwidth-efficient; if two or more transactions in the mempool

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -486,7 +486,7 @@ impl TestManager {
         })
     }
 
-    /// Generates [blocks] regtest blocks.
+    /// Generates `blocks` regtest blocks.
     /// Adds a delay between blocks to allow zaino / zebra to catch up with test.
     pub async fn generate_blocks_with_delay(&self, blocks: u32) {
         for _ in 0..blocks {


### PR DESCRIPTION
- Fix malformed doc-comments across the codebase to build without warnings
  - Escape brackets [] in doc-comments to prevent unintended markup
  - Update broken and obsolete intra-doc links
  - Add proper hyperlink formatting and type qualifications
  - Remove stale and obsolete doc-comments
  - Add CI check to fail builds on doc warnings (cargo doc --no-deps --all-features)
  - Update Dockerfile.ci to support documentation checks